### PR TITLE
Fix driver error code for apiFailureBase

### DIFF
--- a/source/dcompute/driver/error.d
+++ b/source/dcompute/driver/error.d
@@ -44,7 +44,7 @@ enum Status : int {
     setOnActiveProcessError = 36,
     noDeviceError           = 37,
     startupFailure          = 0x7f,
-    apiFailureBase          = 1000,
+    apiFailureBase          = 10000,
     // OpenCL Errors.
     deviceNotFound                 = -1,
     deviceNotAvailable             = -2,


### PR DESCRIPTION
Corrects the apiFailureBase code to match the code in the cuda headers.  Closes #31 