### PR TITLE
[dub.json] Remove ./ prefix from `excludedSourceFiles`

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -13,7 +13,7 @@
         {
             "name": "library",
             "targetType": "library",
-            "excludedSourceFiles": ["./source/dcompute/tests/*"],
+            "excludedSourceFiles": ["source/dcompute/tests/*"],
         },
         {
             "name": "unittest",


### PR DESCRIPTION
Dub will not exclude the test files when prefixed with a ./