### PR TITLE
Support for LDC 1.42.0

### DIFF
--- a/source/dcompute/std/cuda/sync.d
+++ b/source/dcompute/std/cuda/sync.d
@@ -1,12 +1,12 @@
 @compute(CompileFor.deviceOnly) module dcompute.std.cuda.sync;
 
 import ldc.dcompute;
-import core.builtins;
+import ldc.intrinsics;
 
 pragma(LDC_intrinsic, "llvm.nvvm.barrier0")
 void barrier0();
 
-static if (__VENDOR__ == "LDC" && LLVM_atleast!21) { // >= LDC 1.42.0(LLVM 21)
+static if (LLVM_atleast!21) { // >= LDC 1.42.0(LLVM 21)
     pragma(LDC_intrinsic, "llvm.nvvm.barrier.cta.sync.aligned.all")
     void barrier_n(int);
 }

--- a/source/dcompute/std/cuda/sync.d
+++ b/source/dcompute/std/cuda/sync.d
@@ -5,6 +5,11 @@ import ldc.dcompute;
 pragma(LDC_intrinsic, "llvm.nvvm.barrier0")
 void barrier0();
 
+static if (__VENDOR__ == "LDC" && __VERSION__ >= 2112L) { // >= LDC 1.42.0
+    pragma(LDC_intrinsic, "llvm.nvvm.barrier.cta.sync.aligned.all")
+    void barrier_n(int);
+}
+
 pragma(LDC_intrinsic, "llvm.nvvm.barrier0.and")
 int barrier0_and(int);
 

--- a/source/dcompute/std/cuda/sync.d
+++ b/source/dcompute/std/cuda/sync.d
@@ -1,11 +1,12 @@
 @compute(CompileFor.deviceOnly) module dcompute.std.cuda.sync;
 
 import ldc.dcompute;
+import core.builtins;
 
 pragma(LDC_intrinsic, "llvm.nvvm.barrier0")
 void barrier0();
 
-static if (__VENDOR__ == "LDC" && __VERSION__ >= 2112L) { // >= LDC 1.42.0
+static if (__VENDOR__ == "LDC" && LLVM_atleast!21) { // >= LDC 1.42.0(LLVM 21)
     pragma(LDC_intrinsic, "llvm.nvvm.barrier.cta.sync.aligned.all")
     void barrier_n(int);
 }

--- a/source/dcompute/std/sync.d
+++ b/source/dcompute/std/sync.d
@@ -1,7 +1,7 @@
 @compute(CompileFor.deviceOnly) module dcompute.std.sync;
 
 import ldc.dcompute;
-import core.builtins;
+import ldc.intrinsics;
 
 import ocl  = dcompute.std.opencl.sync;
 import cuda = dcompute.std.cuda.sync;
@@ -12,7 +12,7 @@ void barrier()
     if(__dcompute_reflect(ReflectTarget.OpenCL))
         ocl.barrier(0);
     if(__dcompute_reflect(ReflectTarget.CUDA)) {
-        static if (__VENDOR__ == "LDC" && LLVM_atleast!21) { // >= LDC 1.42.0(LLVM 21)
+        static if (LLVM_atleast!21) { // >= LDC 1.42.0(LLVM 21)
             cuda.barrier_n(0);
         } else {
             cuda.barrier0();

--- a/source/dcompute/std/sync.d
+++ b/source/dcompute/std/sync.d
@@ -10,8 +10,13 @@ void barrier()
 {
     if(__dcompute_reflect(ReflectTarget.OpenCL))
         ocl.barrier(0);
-    if(__dcompute_reflect(ReflectTarget.CUDA))
-        cuda.barrier0();
+    if(__dcompute_reflect(ReflectTarget.CUDA)) {
+        static if (__VENDOR__ == "LDC" && __VERSION__ >= 2112L) { // >= LDC 1.42.0
+            cuda.barrier_n(0);
+        } else {
+            cuda.barrier0();
+        }
+    }
 }
 
 void local_fence()

--- a/source/dcompute/std/sync.d
+++ b/source/dcompute/std/sync.d
@@ -1,6 +1,7 @@
 @compute(CompileFor.deviceOnly) module dcompute.std.sync;
 
 import ldc.dcompute;
+import core.builtins;
 
 import ocl  = dcompute.std.opencl.sync;
 import cuda = dcompute.std.cuda.sync;
@@ -11,7 +12,7 @@ void barrier()
     if(__dcompute_reflect(ReflectTarget.OpenCL))
         ocl.barrier(0);
     if(__dcompute_reflect(ReflectTarget.CUDA)) {
-        static if (__VENDOR__ == "LDC" && __VERSION__ >= 2112L) { // >= LDC 1.42.0
+        static if (__VENDOR__ == "LDC" && LLVM_atleast!21) { // >= LDC 1.42.0(LLVM 21)
             cuda.barrier_n(0);
         } else {
             cuda.barrier0();

--- a/source/dcompute/tests/dummykernels.d
+++ b/source/dcompute/tests/dummykernels.d
@@ -3,6 +3,7 @@ module dcompute.tests.dummykernels;
 pragma(LDC_no_moduleinfo);
 
 import ldc.dcompute;
+import core.builtins;
 import dcompute.std.index;
 
 mixin template _saxpy() {
@@ -28,12 +29,12 @@ mixin template _auto_index_test() {
     }
 }
 
-static if (__VENDOR__ == "LDC" && __VERSION__ >= 2112L) { // >= LDC 1.42.0
-    pragma(msg, "using LDC version >= 1.42.0");
+static if (__VENDOR__ == "LDC" && LLVM_atleast!21) { // >= LDC 1.42.0(LLVM 21)
+    pragma(msg, "using LDC version >= 1.42.0(LLVM 21)");
     @kernel() mixin _saxpy;
     @kernel() mixin _auto_index_test;
 } else {
-    pragma(msg, "using LDC version < 1.42.0");
+    pragma(msg, "using LDC version < 1.42.0(LLVM 21)");
     @kernel mixin _saxpy;
     @kernel mixin _auto_index_test;
 }

--- a/source/dcompute/tests/dummykernels.d
+++ b/source/dcompute/tests/dummykernels.d
@@ -3,38 +3,23 @@ module dcompute.tests.dummykernels;
 pragma(LDC_no_moduleinfo);
 
 import ldc.dcompute;
-import ldc.intrinsics;
 import dcompute.std.index;
 
-mixin template _saxpy() {
-    void saxpy(GlobalPointer!(float) res,
-                    float alpha,GlobalPointer!(float) x,
-                    GlobalPointer!(float) y, 
-                    size_t N)
-    {
-        auto i = GlobalIndex.x;
-        if (i >= N) return;
-        res[i] = alpha*x[i] + y[i];
-    }    
+@kernel() void saxpy(GlobalPointer!(float) res,
+                   float alpha,GlobalPointer!(float) x,
+                   GlobalPointer!(float) y, 
+                   size_t N)
+{
+    auto i = GlobalIndex.x;
+    if (i >= N) return;
+    res[i] = alpha*x[i] + y[i];
 }
 
 alias aagf = AutoIndexed!(GlobalPointer!(float));
 
-mixin template _auto_index_test() {
-    void auto_index_test(aagf a,
-                            aagf b,
-                            aagf c)
-    {
-        a = b + c;
-    }
-}
-
-static if (LLVM_atleast!21) { // >= LDC 1.42.0(LLVM 21)
-    pragma(msg, "using LDC version >= 1.42.0(LLVM 21)");
-    @kernel() mixin _saxpy;
-    @kernel() mixin _auto_index_test;
-} else {
-    pragma(msg, "using LDC version < 1.42.0(LLVM 21)");
-    @kernel mixin _saxpy;
-    @kernel mixin _auto_index_test;
+@kernel() void auto_index_test(aagf a,
+                             aagf b,
+                             aagf c)
+{
+    a = b + c;
 }

--- a/source/dcompute/tests/dummykernels.d
+++ b/source/dcompute/tests/dummykernels.d
@@ -3,7 +3,7 @@ module dcompute.tests.dummykernels;
 pragma(LDC_no_moduleinfo);
 
 import ldc.dcompute;
-import core.builtins;
+import ldc.intrinsics;
 import dcompute.std.index;
 
 mixin template _saxpy() {
@@ -29,7 +29,7 @@ mixin template _auto_index_test() {
     }
 }
 
-static if (__VENDOR__ == "LDC" && LLVM_atleast!21) { // >= LDC 1.42.0(LLVM 21)
+static if (LLVM_atleast!21) { // >= LDC 1.42.0(LLVM 21)
     pragma(msg, "using LDC version >= 1.42.0(LLVM 21)");
     @kernel() mixin _saxpy;
     @kernel() mixin _auto_index_test;

--- a/source/dcompute/tests/dummykernels.d
+++ b/source/dcompute/tests/dummykernels.d
@@ -5,21 +5,35 @@ pragma(LDC_no_moduleinfo);
 import ldc.dcompute;
 import dcompute.std.index;
 
-@kernel() void saxpy(GlobalPointer!(float) res,
-                   float alpha,GlobalPointer!(float) x,
-                   GlobalPointer!(float) y, 
-                   size_t N)
-{
-    auto i = GlobalIndex.x;
-    if (i >= N) return;
-    res[i] = alpha*x[i] + y[i];
+mixin template _saxpy() {
+    void saxpy(GlobalPointer!(float) res,
+                    float alpha,GlobalPointer!(float) x,
+                    GlobalPointer!(float) y, 
+                    size_t N)
+    {
+        auto i = GlobalIndex.x;
+        if (i >= N) return;
+        res[i] = alpha*x[i] + y[i];
+    }    
 }
 
 alias aagf = AutoIndexed!(GlobalPointer!(float));
 
-@kernel() void auto_index_test(aagf a,
-                             aagf b,
-                             aagf c)
-{
-    a = b + c;
+mixin template _auto_index_test() {
+    void auto_index_test(aagf a,
+                            aagf b,
+                            aagf c)
+    {
+        a = b + c;
+    }
+}
+
+static if (__VENDOR__ == "LDC" && __VERSION__ >= 2112L) { // >= LDC 1.42.0
+    pragma(msg, "using LDC version >= 1.42.0");
+    @kernel() mixin _saxpy;
+    @kernel() mixin _auto_index_test;
+} else {
+    pragma(msg, "using LDC version < 1.42.0");
+    @kernel mixin _saxpy;
+    @kernel mixin _auto_index_test;
 }

--- a/source/dcompute/tests/dummykernels.d
+++ b/source/dcompute/tests/dummykernels.d
@@ -5,7 +5,7 @@ pragma(LDC_no_moduleinfo);
 import ldc.dcompute;
 import dcompute.std.index;
 
-@kernel void saxpy(GlobalPointer!(float) res,
+@kernel() void saxpy(GlobalPointer!(float) res,
                    float alpha,GlobalPointer!(float) x,
                    GlobalPointer!(float) y, 
                    size_t N)
@@ -17,7 +17,7 @@ import dcompute.std.index;
 
 alias aagf = AutoIndexed!(GlobalPointer!(float));
 
-@kernel void auto_index_test(aagf a,
+@kernel() void auto_index_test(aagf a,
                              aagf b,
                              aagf c)
 {


### PR DESCRIPTION
issue #89

Minimum fixes to work.
- Use `llvm.nvvm.barrier.cta.sync.aligned.all`  instead of `llvm.nvvm.barrier0` for LDC 1.42.0(1.42.0-beta2 or later)
- In the kernel source, switch between @kernel and @kernel() depending on the LDC version.

**Restrictions**: not work for LDC 1.42.0-beta1.

Is there any other way to determine the LDC version?