### PR TITLE
For Metal project---adding drivers

### DIFF
--- a/source/dcompute/driver/metal/bindings.d
+++ b/source/dcompute/driver/metal/bindings.d
@@ -1,0 +1,99 @@
+module dcompute.driver.metal.bindings;
+
+import core.attribute : selector;
+
+alias NSUInteger = ulong;
+
+enum MTLResourceOptions : NSUInteger {
+    storageModeShared = 0,
+}
+
+struct MTLSize {
+    NSUInteger width;
+    NSUInteger height;
+    NSUInteger depth;
+}
+
+extern(Objective-C) interface NSObject {
+    void release();
+}
+
+extern(Objective-C) interface NSAutoreleasePool : NSObject {
+    void drain();
+}
+
+extern(Objective-C) interface NSString : NSObject {}
+
+extern(Objective-C) interface MTLBuffer : NSObject {
+    void* contents();
+}
+
+extern(Objective-C) interface MTLFunction : NSObject {}
+
+extern(Objective-C) interface MTLLibrary : NSObject {
+    @selector("newFunctionWithName:")
+    MTLFunction newFunctionWithName(NSString name);
+}
+
+extern(Objective-C) interface MTLComputePipelineState : NSObject {}
+
+extern(Objective-C) interface MTLComputeCommandEncoder : NSObject {
+    @selector("setComputePipelineState:")
+    void setComputePipelineState(MTLComputePipelineState state);
+
+    @selector("setBuffer:offset:atIndex:")
+    void setBuffer(MTLBuffer buffer, NSUInteger offset, NSUInteger index);
+
+    @selector("dispatchThreads:threadsPerThreadgroup:")
+    void dispatchThreads(MTLSize threadsPerGrid, MTLSize threadsPerThreadgroup);
+
+    void endEncoding();
+}
+
+extern(Objective-C) interface MTLCommandBuffer : NSObject {
+    MTLComputeCommandEncoder computeCommandEncoder();
+    void commit();
+    void waitUntilCompleted();
+}
+
+extern(Objective-C) interface MTLCommandQueue : NSObject {
+    MTLCommandBuffer commandBuffer();
+}
+
+extern(Objective-C) interface MTLDevice : NSObject {
+    MTLCommandQueue newCommandQueue();
+
+    @selector("newLibraryWithFile:error:")
+    MTLLibrary newLibraryWithFile(NSString filePath, void* error);
+
+    @selector("newComputePipelineStateWithFunction:error:")
+    MTLComputePipelineState newComputePipelineStateWithFunction(MTLFunction function_, void* error);
+
+    @selector("newBufferWithBytes:length:options:")
+    MTLBuffer newBufferWithBytes(const(void)* bytes, NSUInteger length, MTLResourceOptions options);
+
+    @selector("newBufferWithLength:options:")
+    MTLBuffer newBufferWithLength(NSUInteger length, MTLResourceOptions options);
+}
+
+extern(C) {
+    alias CFAllocatorRef = const(void)*;
+    alias CFStringEncoding = uint;
+
+    pragma(mangle, "MTLCreateSystemDefaultDevice")
+    MTLDevice mtlCreateSystemDefaultDevice();
+
+    void* CFStringCreateWithCString(CFAllocatorRef alloc, const(char)* cStr, CFStringEncoding encoding);
+}
+
+enum kCFStringEncodingUTF8 = 0x08000100;
+
+MTLSize mtlSize(NSUInteger w, NSUInteger h = 1, NSUInteger d = 1) {
+    return MTLSize(w, h, d);
+}
+
+NSString nsString(const(char)[] text) {
+    auto cfStr = CFStringCreateWithCString(null, (text ~ "\0").ptr, kCFStringEncodingUTF8);
+    return cast(NSString) cfStr;
+}
+

--- a/source/dcompute/driver/metal/bindings.d
+++ b/source/dcompute/driver/metal/bindings.d
@@ -44,6 +44,9 @@ extern(Objective-C) interface MTLComputeCommandEncoder : NSObject {
     @selector("setBuffer:offset:atIndex:")
     void setBuffer(MTLBuffer buffer, NSUInteger offset, NSUInteger index);
 
+    @selector("setBytes:length:atIndex:")
+    void setBytes(const(void)* bytes, NSUInteger length, NSUInteger index);
+
     @selector("setThreadgroupMemoryLength:atIndex:")
     void setThreadgroupMemoryLength(NSUInteger length, NSUInteger index);
 

--- a/source/dcompute/driver/metal/bindings.d
+++ b/source/dcompute/driver/metal/bindings.d
@@ -44,6 +44,9 @@ extern(Objective-C) interface MTLComputeCommandEncoder : NSObject {
     @selector("setBuffer:offset:atIndex:")
     void setBuffer(MTLBuffer buffer, NSUInteger offset, NSUInteger index);
 
+    @selector("setThreadgroupMemoryLength:atIndex:")
+    void setThreadgroupMemoryLength(NSUInteger length, NSUInteger index);
+
     @selector("dispatchThreads:threadsPerThreadgroup:")
     void dispatchThreads(MTLSize threadsPerGrid, MTLSize threadsPerThreadgroup);
 

--- a/source/dcompute/driver/metal/buffer.d
+++ b/source/dcompute/driver/metal/buffer.d
@@ -1,0 +1,43 @@
+module dcompute.driver.metal.buffer;
+
+import dcompute.driver.metal.device;
+import dcompute.driver.metal.bindings;
+
+// No need for host<->device copy calls, since Metal buffers can be shared between CPU and GPU.
+// Just create the buffer with storageModeShared and use contents() to get a pointer to the data for both host and device access.
+struct Buffer(T) {
+
+    // Store as void* to avoid emitting RTTI/classinfo for extern(Objective-C) interfaces.
+    private void* raw_;
+
+    this(size_t elems) {
+        auto dev = defaultDevice().raw;
+        auto byteCount = cast(NSUInteger)(elems * T.sizeof);
+        raw = dev.newBufferWithLength(byteCount, MTLResourceOptions.storageModeShared);
+    }
+
+    this(const(T)[] arr) {
+        auto dev = defaultDevice().raw;
+        auto byteCount = cast(NSUInteger)(arr.length * T.sizeof);
+        raw = dev.newBufferWithBytes(arr.ptr, byteCount, MTLResourceOptions.storageModeShared);
+    }
+
+    @property MTLBuffer raw() {
+        return cast(MTLBuffer) raw_;
+    }
+
+    @property void raw(MTLBuffer buf) {
+        raw_ = cast(void*) buf;
+    }
+
+    void* contents() {
+        auto buf = raw();
+        return (buf is null) ? null : buf.contents();
+    }
+
+    void release() {
+        auto buf = raw();
+        if (buf !is null) buf.release();
+        raw_ = null;
+    }
+}

--- a/source/dcompute/driver/metal/device.d
+++ b/source/dcompute/driver/metal/device.d
@@ -1,0 +1,35 @@
+module dcompute.driver.metal.device;
+
+import dcompute.driver.metal.bindings;
+
+struct Device {
+    private void* raw_;
+
+    @property MTLDevice raw() {
+        return cast(MTLDevice) raw_;
+    }
+
+    @property void raw(MTLDevice device) {
+        raw_ = cast(void*) device;
+    }
+
+    void release() {
+        auto dev = raw();
+        if (dev !is null) dev.release();
+    }
+}
+
+__gshared void* g_defaultDevice;
+
+Device defaultDevice() {
+    Device dev;
+    if (g_defaultDevice is null) {
+        g_defaultDevice = cast(void*) mtlCreateSystemDefaultDevice();
+    }
+    dev.raw = cast(MTLDevice) g_defaultDevice;
+    return dev;
+}
+
+void setDefaultDevice(MTLDevice device) {
+    g_defaultDevice = cast(void*) device;
+}

--- a/source/dcompute/driver/metal/encoder.d
+++ b/source/dcompute/driver/metal/encoder.d
@@ -1,0 +1,43 @@
+module dcompute.driver.metal.encoder;
+
+import dcompute.driver.metal.buffer;
+import dcompute.driver.metal.program;
+import dcompute.driver.metal.bindings;
+
+struct Encoder {
+    private void* raw_;
+
+    @property MTLComputeCommandEncoder raw() {
+        return cast(MTLComputeCommandEncoder) raw_;
+    }
+
+    @property void raw(MTLComputeCommandEncoder enc) {
+        raw_ = cast(void*) enc;
+    }
+
+    void setPipeline(Pipeline pipeline) {
+        auto enc = raw();
+        if (enc !is null) enc.setComputePipelineState(pipeline.raw);
+    }
+
+    void setBuffer(T)(Buffer!T buffer, NSUInteger offset, NSUInteger index) {
+        auto enc = raw();
+        if (enc !is null) enc.setBuffer(buffer.raw, offset, index);
+    }
+
+    void dispatchThreads(MTLSize threadsPerGrid, MTLSize threadsPerThreadgroup) {
+        auto enc = raw();
+        if (enc !is null) enc.dispatchThreads(threadsPerGrid, threadsPerThreadgroup);
+    }
+
+    void endEncoding() {
+        auto enc = raw();
+        if (enc !is null) enc.endEncoding();
+    }
+
+    void release() {
+        auto enc = raw();
+        if (enc !is null) enc.release();
+        raw_ = null;
+    }
+}

--- a/source/dcompute/driver/metal/encoder.d
+++ b/source/dcompute/driver/metal/encoder.d
@@ -25,6 +25,11 @@ struct Encoder {
         if (enc !is null) enc.setBuffer(buffer.raw, offset, index);
     }
 
+    void setBytes(const(void)* bytes, NSUInteger length, NSUInteger index) {
+        auto enc = raw();
+        if (enc !is null) enc.setBytes(bytes, length, index);
+    }
+
     void setThreadgroupMemoryLength(NSUInteger length, NSUInteger index) {
         auto enc = raw();
         if (enc !is null) enc.setThreadgroupMemoryLength(length, index);

--- a/source/dcompute/driver/metal/encoder.d
+++ b/source/dcompute/driver/metal/encoder.d
@@ -25,6 +25,11 @@ struct Encoder {
         if (enc !is null) enc.setBuffer(buffer.raw, offset, index);
     }
 
+    void setThreadgroupMemoryLength(NSUInteger length, NSUInteger index) {
+        auto enc = raw();
+        if (enc !is null) enc.setThreadgroupMemoryLength(length, index);
+    }
+
     void dispatchThreads(MTLSize threadsPerGrid, MTLSize threadsPerThreadgroup) {
         auto enc = raw();
         if (enc !is null) enc.dispatchThreads(threadsPerGrid, threadsPerThreadgroup);

--- a/source/dcompute/driver/metal/package.d
+++ b/source/dcompute/driver/metal/package.d
@@ -1,0 +1,9 @@
+module dcompute.driver.metal;
+
+public import dcompute.driver.metal.bindings : mtlSize;
+public import dcompute.driver.metal.device;
+public import dcompute.driver.metal.buffer;
+public import dcompute.driver.metal.platform;
+public import dcompute.driver.metal.queue;
+public import dcompute.driver.metal.program;
+public import dcompute.driver.metal.encoder;

--- a/source/dcompute/driver/metal/platform.d
+++ b/source/dcompute/driver/metal/platform.d
@@ -1,0 +1,15 @@
+module dcompute.driver.metal.platform;
+
+import dcompute.driver.metal.device;
+
+struct Platform {
+    static void initialise() {
+        // Metal has no explicit global init step in this backend.
+    }
+
+    static Device[] getDevices() {
+        // Current implementation exposes only the default device.
+        // TODO: Enumerate all Metal devices (for multi-GPU systems).
+        return [defaultDevice()];
+    }
+}

--- a/source/dcompute/driver/metal/program.d
+++ b/source/dcompute/driver/metal/program.d
@@ -1,0 +1,92 @@
+module dcompute.driver.metal.program;
+
+import dcompute.driver.metal.device;
+import dcompute.driver.metal.bindings;
+
+struct Library {
+    private void* raw_;
+
+    @property MTLLibrary raw() {
+        return cast(MTLLibrary) raw_;
+    }
+
+    @property void raw(MTLLibrary lib) {
+        raw_ = cast(void*) lib;
+    }
+
+    void release() {
+        auto lib = raw();
+        if (lib !is null) lib.release();
+        raw_ = null;
+    }
+
+    MTLFunction newFunction(const(char)[] name) {
+        auto lib = raw();
+        return (lib is null) ? null : lib.newFunctionWithName(nsString(name));
+    }
+}
+
+struct Pipeline {
+    private void* raw_;
+
+    @property MTLComputePipelineState raw() {
+        return cast(MTLComputePipelineState) raw_;
+    }
+
+    @property void raw(MTLComputePipelineState pso) {
+        raw_ = cast(void*) pso;
+    }
+
+    void release() {
+        auto pso = raw();
+        if (pso !is null) pso.release();
+        raw_ = null;
+    }
+}
+
+struct Kernel {
+    Pipeline pipeline;
+
+    void release() {
+        pipeline.release();
+    }
+}
+
+struct Program {
+    Device device;
+    Library library;
+
+    static Program fromDefaultDevice() {
+        Program p;
+        p.device = defaultDevice();
+        return p;
+    }
+
+    Library loadLibrary(const(char)[] path) {
+        auto dev = device.raw;
+        library.raw = (dev is null) ? null : dev.newLibraryWithFile(nsString(path), null);
+        return library;
+    }
+
+    Pipeline makePipeline(MTLFunction fn) {
+        Pipeline pso;
+        auto dev = device.raw;
+        pso.raw = (dev is null) ? null : dev.newComputePipelineStateWithFunction(fn, null);
+        return pso;
+    }
+
+    Kernel getKernel(const(char)[] name) {
+        Kernel k;
+        auto lib = library.raw;
+        if (lib is null) return k;
+        auto fn = lib.newFunctionWithName(nsString(name));
+        if (fn is null) return k;
+        k.pipeline = makePipeline(fn);
+        fn.release();
+        return k;
+    }
+
+    void release() {
+        library.release();
+    }
+}

--- a/source/dcompute/driver/metal/queue.d
+++ b/source/dcompute/driver/metal/queue.d
@@ -1,0 +1,121 @@
+module dcompute.driver.metal.queue;
+
+import dcompute.driver.metal.device;
+import dcompute.driver.metal.encoder;
+import dcompute.driver.metal.program;
+import dcompute.driver.metal.bindings;
+import dcompute.driver.metal.buffer;
+import std.meta : allSatisfy;
+
+private enum isBuffer(T) = is(T == Buffer!U, U);
+
+struct CommandBuffer {
+    private void* raw_;
+
+    @property MTLCommandBuffer raw() {
+        return cast(MTLCommandBuffer) raw_;
+    }
+
+    @property void raw(MTLCommandBuffer buf) {
+        raw_ = cast(void*) buf;
+    }
+
+    void commit() {
+        auto buf = raw();
+        if (buf !is null) buf.commit();
+    }
+
+    void waitUntilCompleted() {
+        auto buf = raw();
+        if (buf !is null) buf.waitUntilCompleted();
+    }
+
+    Encoder computeEncoder() {
+        Encoder enc;
+        auto buf = raw();
+        enc.raw = (buf is null) ? null : buf.computeCommandEncoder();
+        return enc;
+    }
+
+    void release() {
+        auto buf = raw();
+        if (buf !is null) buf.release();
+        raw_ = null;
+    }
+}
+
+struct Queue {
+    private void* raw_;
+
+    this(Device dev) {
+        auto q = dev.raw.newCommandQueue();
+        raw_ = cast(void*) q;
+    }
+
+    @property MTLCommandQueue raw() {
+        return cast(MTLCommandQueue) raw_;
+    }
+
+    @property void raw(MTLCommandQueue q) {
+        raw_ = cast(void*) q;
+    }
+
+    CommandBuffer commandBuffer() {
+        CommandBuffer cb;
+        auto q = raw();
+        cb.raw = (q is null) ? null : q.commandBuffer();
+        return cb;
+    }
+
+    void release() {
+        auto q = raw();
+        if (q !is null) q.release();
+        raw_ = null;
+    }
+
+    void enqueue(Buffers...)(Pipeline pipeline, MTLSize grid, MTLSize group, Buffers buffers)
+        if (allSatisfy!(isBuffer, Buffers)) {
+        auto cmdBuffer = commandBuffer();
+        if (cmdBuffer.raw is null) return;
+        auto encoder = cmdBuffer.computeEncoder();
+        if (encoder.raw is null) {
+            cmdBuffer.release();
+            return;
+        }
+        scope(exit) cmdBuffer.release();
+        scope(exit) encoder.release();
+
+        encoder.setPipeline(pipeline);
+        foreach (i, ref buf; buffers) {
+            encoder.setBuffer(buf, 0, cast(NSUInteger) i);
+        }
+        encoder.dispatchThreads(grid, group);
+        encoder.endEncoding();
+        cmdBuffer.commit();
+        cmdBuffer.waitUntilCompleted();
+    }
+
+
+    auto enqueue(Kernel kernel, MTLSize grid, MTLSize group) {
+        static struct Launch {
+            Queue q;
+            Kernel k;
+            MTLSize grid;
+            MTLSize group;
+
+            this(Queue q, Kernel k, MTLSize grid, MTLSize group) {
+                this.q = q;
+                this.k = k;
+                this.grid = grid;
+                this.group = group;
+            }
+
+            void opCall(Buffers...)(Buffers buffers)
+                if (allSatisfy!(isBuffer, Buffers)) {
+                q.enqueue(k.pipeline, grid, group, buffers);
+            }
+        }
+
+        return Launch(this, kernel, grid, group);
+    }
+}

--- a/source/dcompute/driver/metal/queue.d
+++ b/source/dcompute/driver/metal/queue.d
@@ -6,8 +6,21 @@ import dcompute.driver.metal.program;
 import dcompute.driver.metal.bindings;
 import dcompute.driver.metal.buffer;
 import std.meta : allSatisfy;
+import std.traits : isNumeric, Unqual;
 
-private enum isBuffer(T) = is(T == Buffer!U, U);
+private enum isBuffer(T) = is(Unqual!T == Buffer!U, U);
+private enum isThreadgroupMemory(T) = is(Unqual!T == ThreadgroupMemory);
+private enum isScalarKernelArgument(T) = isNumeric!(Unqual!T);
+private enum isKernelArgument(T) =
+    isBuffer!T || isThreadgroupMemory!T || isScalarKernelArgument!T;
+
+struct ThreadgroupMemory {
+    NSUInteger length;
+}
+
+ThreadgroupMemory threadgroupMemory(NSUInteger length) {
+    return ThreadgroupMemory(length);
+}
 
 struct CommandBuffer {
     private void* raw_;
@@ -73,8 +86,8 @@ struct Queue {
         raw_ = null;
     }
 
-    void enqueue(Buffers...)(Pipeline pipeline, MTLSize grid, MTLSize group, Buffers buffers)
-        if (allSatisfy!(isBuffer, Buffers)) {
+    void enqueue(Args...)(Pipeline pipeline, MTLSize grid, MTLSize group, Args args)
+        if (allSatisfy!(isKernelArgument, Args)) {
         auto cmdBuffer = commandBuffer();
         if (cmdBuffer.raw is null) return;
         auto encoder = cmdBuffer.computeEncoder();
@@ -86,8 +99,8 @@ struct Queue {
         scope(exit) encoder.release();
 
         encoder.setPipeline(pipeline);
-        foreach (i, ref buf; buffers) {
-            encoder.setBuffer(buf, 0, cast(NSUInteger) i);
+        foreach (i, ref arg; args) {
+            encodeKernelArgument(encoder, arg, cast(NSUInteger) i);
         }
         encoder.dispatchThreads(grid, group);
         encoder.endEncoding();
@@ -110,12 +123,27 @@ struct Queue {
                 this.group = group;
             }
 
-            void opCall(Buffers...)(Buffers buffers)
-                if (allSatisfy!(isBuffer, Buffers)) {
-                q.enqueue(k.pipeline, grid, group, buffers);
+            void opCall(Args...)(Args args)
+                if (allSatisfy!(isKernelArgument, Args)) {
+                q.enqueue(k.pipeline, grid, group, args);
             }
         }
 
         return Launch(this, kernel, grid, group);
     }
+}
+
+private void encodeKernelArgument(T)(ref Encoder encoder, ref T buffer, NSUInteger index)
+    if (isBuffer!T) {
+    encoder.setBuffer(buffer, 0, index);
+}
+
+private void encodeKernelArgument(T)(ref Encoder encoder, ref T memory, NSUInteger index)
+    if (isThreadgroupMemory!T) {
+    encoder.setThreadgroupMemoryLength(memory.length, index);
+}
+
+private void encodeKernelArgument(T)(ref Encoder encoder, ref T value, NSUInteger index)
+    if (isScalarKernelArgument!T) {
+    encoder.setBytes(&value, T.sizeof, index);
 }

--- a/source/dcompute/std/atomic.d
+++ b/source/dcompute/std/atomic.d
@@ -3,20 +3,25 @@
 import ldc.dcompute;
 
 import cuda = dcompute.std.cuda.atomic;
+import metal = dcompute.std.metal.atomic;
 public import dcompute.std.atomic_common : MemoryOrder;
 
 int atomicAddShared(MemoryOrder mo = MemoryOrder.seq_cst)(SharedPointer!int dst, int val)
 {
-	if(__dcompute_reflect(ReflectTarget.CUDA))
-		return cuda.atomicAddShared!mo(dst, val);
-	assert(0);
+    if(__dcompute_reflect(ReflectTarget.CUDA))
+        return cuda.atomicAddShared!mo(dst, val);
+    if(__dcompute_reflect(ReflectTarget.OpenCL))
+        assert(0);
+    return metal.atomicAddShared!mo(dst, val);
 }
 
 int atomicAdd(MemoryOrder mo = MemoryOrder.seq_cst)(GlobalPointer!int dst, int val)
 {
-	if(__dcompute_reflect(ReflectTarget.CUDA))
-		return cuda.atomicAdd!mo(dst, val);
-	assert(0);
+    if(__dcompute_reflect(ReflectTarget.CUDA))
+        return cuda.atomicAdd!mo(dst, val);
+    if(__dcompute_reflect(ReflectTarget.OpenCL))
+        assert(0);
+    return metal.atomicAdd!mo(dst, val);
 }
 /*
  * @brief Atomically exchanges the value at the address with a new value.
@@ -28,17 +33,20 @@ int atomicExchange(MemoryOrder mo = MemoryOrder.seq_cst)
                   (GlobalPointer!int dst, int newVal)
 {
     if (__dcompute_reflect(ReflectTarget.CUDA))
-		return cuda.atomicExchange!mo(dst, newVal);
-	assert(0);
+        return cuda.atomicExchange!mo(dst, newVal);
+    if(__dcompute_reflect(ReflectTarget.OpenCL))
+        assert(0);
+    return metal.atomicExchange!mo(dst, newVal);
 }
 
 int atomicExchangeShared(MemoryOrder mo = MemoryOrder.seq_cst)(SharedPointer!int dst, int newVal)
 {
-	if(__dcompute_reflect(ReflectTarget.CUDA))
-		return cuda.atomicExchangeShared!mo(dst, newVal);
-	assert(0);
+    if(__dcompute_reflect(ReflectTarget.CUDA))
+        return cuda.atomicExchangeShared!mo(dst, newVal);
+    if(__dcompute_reflect(ReflectTarget.OpenCL))
+        assert(0);
+    return metal.atomicExchangeShared!mo(dst, newVal);
 }
-
 /*
  *Atomic:
  * T add (GenericPointer!T addr,T val)

--- a/source/dcompute/std/index.d
+++ b/source/dcompute/std/index.d
@@ -2,8 +2,9 @@
 
 import ldc.dcompute;
 
-private import ocl  = dcompute.std.opencl.index;
-private import cuda = dcompute.std.cuda.index;
+private import ocl   = dcompute.std.opencl.index;
+private import cuda  = dcompute.std.cuda.index;
+private import metal = dcompute.std.metal.index;
 
 /*
  Index Terminology
@@ -46,6 +47,8 @@ struct GlobalDimension
             return ocl.get_global_size(0);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.ntid_x()*cuda.nctaid_x();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_global_size_x();
         else
             assert(0);
     }
@@ -56,6 +59,8 @@ struct GlobalDimension
             return ocl.get_global_size(1);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.ntid_y()*cuda.nctaid_y();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_global_size_y();
         else
             assert(0);
     }
@@ -66,6 +71,8 @@ struct GlobalDimension
             return ocl.get_global_size(2);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.ntid_z()*cuda.nctaid_z();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_global_size_z();
         else
             assert(0);
     }
@@ -80,6 +87,8 @@ struct GlobalIndex
             return ocl.get_global_id(0);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.ctaid_x()*cuda.ntid_x() + cuda.tid_x();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_global_id_x();
         else
             assert(0);
     }
@@ -90,6 +99,8 @@ struct GlobalIndex
             return ocl.get_global_id(1);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.ctaid_y()*cuda.ntid_y() + cuda.tid_y();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_global_id_y();
         else
             assert(0);
     }
@@ -100,6 +111,8 @@ struct GlobalIndex
             return ocl.get_global_id(2);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.ctaid_z()*cuda.ntid_z() + cuda.tid_z();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_global_id_z();
         else
             assert(0);
     }
@@ -139,6 +152,8 @@ struct GroupDimension
             return ocl.get_num_groups(0);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.nctaid_x();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_num_groups_x();
         else
             assert(0);
     }
@@ -149,6 +164,8 @@ struct GroupDimension
             return ocl.get_num_groups(1);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.nctaid_y();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_num_groups_y();
         else
             assert(0);
     }
@@ -159,6 +176,8 @@ struct GroupDimension
             return ocl.get_num_groups(2);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.nctaid_z();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_num_groups_z();
         else
             assert(0);
     }
@@ -173,6 +192,8 @@ struct GroupIndex
             return ocl.get_group_id(0);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.ctaid_x();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_group_id_x();
         else
             assert(0);
     }
@@ -183,6 +204,8 @@ struct GroupIndex
             return ocl.get_group_id(1);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.ctaid_y();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_group_id_y();
         else
             assert(0);
     }
@@ -193,6 +216,8 @@ struct GroupIndex
             return ocl.get_group_id(2);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.ctaid_z();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_group_id_z();
         else
             assert(0);
     }
@@ -207,6 +232,8 @@ struct SharedDimension
             return ocl.get_local_size(0);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.ntid_x();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_local_size_x();
         else
             assert(0);
     }
@@ -217,9 +244,10 @@ struct SharedDimension
             return ocl.get_local_size(1);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.ntid_y();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_local_size_y();
         else
             assert(0);
-
     }
     pragma(inline,true);
     @property static size_t z()()
@@ -228,6 +256,8 @@ struct SharedDimension
             return ocl.get_local_size(2);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.ntid_z();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_local_size_z();
         else
             assert(0);
     }
@@ -242,6 +272,8 @@ struct SharedIndex
             return ocl.get_local_id(0);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.tid_x();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_local_id_x();
         else
             assert(0);
     }
@@ -252,6 +284,8 @@ struct SharedIndex
             return ocl.get_local_id(1);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.tid_y();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_local_id_y();
         else
             assert(0);
     }
@@ -262,6 +296,8 @@ struct SharedIndex
             return ocl.get_local_id(2);
         else if(__dcompute_reflect(ReflectTarget.CUDA,0))
             return cuda.tid_z();
+        else if(__dcompute_reflect(ReflectTarget.Metal,0))
+            return metal.get_local_id_z();
         else
             assert(0);
     }

--- a/source/dcompute/std/metal/atomic.d
+++ b/source/dcompute/std/metal/atomic.d
@@ -1,0 +1,135 @@
+@compute(CompileFor.deviceOnly) module dcompute.std.metal.atomic;
+
+import ldc.dcompute;
+import dcompute.std.atomic_common : MemoryOrder;
+
+pragma(LDC_inline_ir)
+    R inlineIR(string s, R, P...)(P);
+
+int atomicAddShared(MemoryOrder mo = MemoryOrder.seq_cst)(SharedPointer!int dst, int val)
+{
+    static if (mo == MemoryOrder.relaxed) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(3)
+            %old = atomicrmw add ptr addrspace(3) %ptr, i32 %1 monotonic
+            ret i32 %old`, int)(cast(long)dst, cast(int)val);
+    } else static if (mo == MemoryOrder.acquire) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(3)
+            %old = atomicrmw add ptr addrspace(3) %ptr, i32 %1 acquire
+            ret i32 %old`, int)(cast(long)dst, cast(int)val);
+    } else static if (mo == MemoryOrder.release) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(3)
+            %old = atomicrmw add ptr addrspace(3) %ptr, i32 %1 release
+            ret i32 %old`, int)(cast(long)dst, cast(int)val);
+    } else static if (mo == MemoryOrder.acq_rel) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(3)
+            %old = atomicrmw add ptr addrspace(3) %ptr, i32 %1 acq_rel
+            ret i32 %old`, int)(cast(long)dst, cast(int)val);
+    } else static if (mo == MemoryOrder.seq_cst) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(3)
+            %old = atomicrmw add ptr addrspace(3) %ptr, i32 %1 seq_cst
+            ret i32 %old`, int)(cast(long)dst, cast(int)val);
+    }
+    else
+        static assert(0, "atomicAddShared doesn't support memoryOrder " ~mo.stringof);
+}
+
+int atomicAdd(MemoryOrder mo = MemoryOrder.seq_cst)(GlobalPointer!int dst, int val)
+{
+    static if (mo == MemoryOrder.relaxed) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(1)
+            %old = atomicrmw add ptr addrspace(1) %ptr, i32 %1 monotonic
+            ret i32 %old`, int)(cast(long)dst, cast(int)val);
+    } else static if (mo == MemoryOrder.acquire) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(1)
+            %old = atomicrmw add ptr addrspace(1) %ptr, i32 %1 acquire
+            ret i32 %old`, int)(cast(long)dst, cast(int)val);
+    } else static if (mo == MemoryOrder.release) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(1)
+            %old = atomicrmw add ptr addrspace(1) %ptr, i32 %1 release
+            ret i32 %old`, int)(cast(long)dst, cast(int)val);
+    } else static if (mo == MemoryOrder.acq_rel) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(1)
+            %old = atomicrmw add ptr addrspace(1) %ptr, i32 %1 acq_rel
+            ret i32 %old`, int)(cast(long)dst, cast(int)val);
+    } else static if (mo == MemoryOrder.seq_cst) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(1)
+            %old = atomicrmw add ptr addrspace(1) %ptr, i32 %1 seq_cst
+            ret i32 %old`, int)(cast(long)dst, cast(int)val);
+    }
+    else
+        static assert(0, "atomicAdd doesn't support memoryOrder " ~mo.stringof);
+}
+
+int atomicExchangeShared(MemoryOrder mo = MemoryOrder.seq_cst)(SharedPointer!int dst, int newVal)
+{
+    static if (mo == MemoryOrder.relaxed) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(3)
+            %old = atomicrmw xchg ptr addrspace(3) %ptr, i32 %1 monotonic
+            ret i32 %old`, int)(cast(long)dst, newVal);
+    } else static if (mo == MemoryOrder.acquire) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(3)
+            %old = atomicrmw xchg ptr addrspace(3) %ptr, i32 %1 acquire
+            ret i32 %old`, int)(cast(long)dst, newVal);
+    } else static if (mo == MemoryOrder.release) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(3)
+            %old = atomicrmw xchg ptr addrspace(3) %ptr, i32 %1 release
+            ret i32 %old`, int)(cast(long)dst, newVal);
+    } else static if (mo == MemoryOrder.acq_rel) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(3)
+            %old = atomicrmw xchg ptr addrspace(3) %ptr, i32 %1 acq_rel
+            ret i32 %old`, int)(cast(long)dst, newVal);
+    } else static if (mo == MemoryOrder.seq_cst) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(3)
+            %old = atomicrmw xchg ptr addrspace(3) %ptr, i32 %1 seq_cst
+            ret i32 %old`, int)(cast(long)dst, newVal);
+    }
+    else
+        static assert(0, "atomicExchangeShared doesn't support memoryOrder " ~mo.stringof);
+}
+
+int atomicExchange(MemoryOrder mo = MemoryOrder.seq_cst)(GlobalPointer!int dst, int newVal)
+{
+    static if (mo == MemoryOrder.relaxed) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(1)
+            %old = atomicrmw xchg ptr addrspace(1) %ptr, i32 %1 monotonic
+            ret i32 %old`, int)(cast(long)dst, newVal);
+    } else static if (mo == MemoryOrder.acquire) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(1)
+            %old = atomicrmw xchg ptr addrspace(1) %ptr, i32 %1 acquire
+            ret i32 %old`, int)(cast(long)dst, newVal);
+    } else static if (mo == MemoryOrder.release) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(1)
+            %old = atomicrmw xchg ptr addrspace(1) %ptr, i32 %1 release
+            ret i32 %old`, int)(cast(long)dst, newVal);
+    } else static if (mo == MemoryOrder.acq_rel) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(1)
+            %old = atomicrmw xchg ptr addrspace(1) %ptr, i32 %1 acq_rel
+            ret i32 %old`, int)(cast(long)dst, newVal);
+    } else static if (mo == MemoryOrder.seq_cst) {
+        return inlineIR!(`
+            %ptr = inttoptr i64 %0 to ptr addrspace(1)
+            %old = atomicrmw xchg ptr addrspace(1) %ptr, i32 %1 seq_cst
+            ret i32 %old`, int)(cast(long)dst, newVal);
+    }
+    else
+        static assert(0, "atomicExchange doesn't support memoryOrder " ~mo.stringof);
+}

--- a/source/dcompute/std/metal/index.d
+++ b/source/dcompute/std/metal/index.d
@@ -1,0 +1,34 @@
+@compute(CompileFor.deviceOnly) module dcompute.std.metal.index;
+
+import ldc.dcompute;
+pure: nothrow: @nogc:
+
+// thread_position_in_grid → GlobalIndex
+pragma(mangle, "air.thread_position_in_grid.x") uint get_global_id_x();
+pragma(mangle, "air.thread_position_in_grid.y") uint get_global_id_y();
+pragma(mangle, "air.thread_position_in_grid.z") uint get_global_id_z();
+
+// thread_position_in_threadgroup → SharedIndex
+pragma(mangle, "air.thread_position_in_threadgroup.x") uint get_local_id_x();
+pragma(mangle, "air.thread_position_in_threadgroup.y") uint get_local_id_y();
+pragma(mangle, "air.thread_position_in_threadgroup.z") uint get_local_id_z();
+
+// threadgroup_position_in_grid → GroupIndex
+pragma(mangle, "air.threadgroup_position_in_grid.x") uint get_group_id_x();
+pragma(mangle, "air.threadgroup_position_in_grid.y") uint get_group_id_y();
+pragma(mangle, "air.threadgroup_position_in_grid.z") uint get_group_id_z();
+
+// threads_per_grid → GlobalDimension
+pragma(mangle, "air.threads_per_grid.x") uint get_global_size_x();
+pragma(mangle, "air.threads_per_grid.y") uint get_global_size_y();
+pragma(mangle, "air.threads_per_grid.z") uint get_global_size_z();
+
+// threads_per_threadgroup → SharedDimension
+pragma(mangle, "air.threads_per_threadgroup.x") uint get_local_size_x();
+pragma(mangle, "air.threads_per_threadgroup.y") uint get_local_size_y();
+pragma(mangle, "air.threads_per_threadgroup.z") uint get_local_size_z();
+
+// threadgroups_per_grid → GroupDimension
+pragma(mangle, "air.threadgroups_per_grid.x") uint get_num_groups_x();
+pragma(mangle, "air.threadgroups_per_grid.y") uint get_num_groups_y();
+pragma(mangle, "air.threadgroups_per_grid.z") uint get_num_groups_z();

--- a/source/dcompute/std/metal/index.d
+++ b/source/dcompute/std/metal/index.d
@@ -3,32 +3,39 @@
 import ldc.dcompute;
 pure: nothrow: @nogc:
 
+pragma(LDC_intrinsic, "air.get_global_id.i32") uint get_global_id(uint dim);
+pragma(LDC_intrinsic, "air.get_local_id.i32") uint get_local_id(uint dim);
+pragma(LDC_intrinsic, "air.get_group_id.i32") uint get_group_id(uint dim);
+pragma(LDC_intrinsic, "air.get_global_size.i32") uint get_global_size(uint dim);
+pragma(LDC_intrinsic, "air.get_local_size.i32") uint get_local_size(uint dim);
+pragma(LDC_intrinsic, "air.get_num_groups.i32") uint get_num_groups(uint dim);
+
 // thread_position_in_grid → GlobalIndex
-pragma(LDC_intrinsic, "air.thread_position_in_grid.x") uint get_global_id_x();
-pragma(LDC_intrinsic, "air.thread_position_in_grid.y") uint get_global_id_y();
-pragma(LDC_intrinsic, "air.thread_position_in_grid.z") uint get_global_id_z();
+uint get_global_id_x()() { return get_global_id(0); }
+uint get_global_id_y()() { return get_global_id(1); }
+uint get_global_id_z()() { return get_global_id(2); }
 
 // thread_position_in_threadgroup → SharedIndex
-pragma(LDC_intrinsic, "air.thread_position_in_threadgroup.x") uint get_local_id_x();
-pragma(LDC_intrinsic, "air.thread_position_in_threadgroup.y") uint get_local_id_y();
-pragma(LDC_intrinsic, "air.thread_position_in_threadgroup.z") uint get_local_id_z();
+uint get_local_id_x()() { return get_local_id(0); }
+uint get_local_id_y()() { return get_local_id(1); }
+uint get_local_id_z()() { return get_local_id(2); }
 
 // threadgroup_position_in_grid → GroupIndex
-pragma(LDC_intrinsic, "air.threadgroup_position_in_grid.x") uint get_group_id_x();
-pragma(LDC_intrinsic, "air.threadgroup_position_in_grid.y") uint get_group_id_y();
-pragma(LDC_intrinsic, "air.threadgroup_position_in_grid.z") uint get_group_id_z();
+uint get_group_id_x()() { return get_group_id(0); }
+uint get_group_id_y()() { return get_group_id(1); }
+uint get_group_id_z()() { return get_group_id(2); }
 
 // threads_per_grid → GlobalDimension
-pragma(LDC_intrinsic, "air.threads_per_grid.x") uint get_global_size_x();
-pragma(LDC_intrinsic, "air.threads_per_grid.y") uint get_global_size_y();
-pragma(LDC_intrinsic, "air.threads_per_grid.z") uint get_global_size_z();
+uint get_global_size_x()() { return get_global_size(0); }
+uint get_global_size_y()() { return get_global_size(1); }
+uint get_global_size_z()() { return get_global_size(2); }
 
 // threads_per_threadgroup → SharedDimension
-pragma(LDC_intrinsic, "air.threads_per_threadgroup.x") uint get_local_size_x();
-pragma(LDC_intrinsic, "air.threads_per_threadgroup.y") uint get_local_size_y();
-pragma(LDC_intrinsic, "air.threads_per_threadgroup.z") uint get_local_size_z();
+uint get_local_size_x()() { return get_local_size(0); }
+uint get_local_size_y()() { return get_local_size(1); }
+uint get_local_size_z()() { return get_local_size(2); }
 
 // threadgroups_per_grid → GroupDimension
-pragma(LDC_intrinsic, "air.threadgroups_per_grid.x") uint get_num_groups_x();
-pragma(LDC_intrinsic, "air.threadgroups_per_grid.y") uint get_num_groups_y();
-pragma(LDC_intrinsic, "air.threadgroups_per_grid.z") uint get_num_groups_z();
+uint get_num_groups_x()() { return get_num_groups(0); }
+uint get_num_groups_y()() { return get_num_groups(1); }
+uint get_num_groups_z()() { return get_num_groups(2); }

--- a/source/dcompute/std/metal/index.d
+++ b/source/dcompute/std/metal/index.d
@@ -4,31 +4,31 @@ import ldc.dcompute;
 pure: nothrow: @nogc:
 
 // thread_position_in_grid → GlobalIndex
-pragma(mangle, "air.thread_position_in_grid.x") uint get_global_id_x();
-pragma(mangle, "air.thread_position_in_grid.y") uint get_global_id_y();
-pragma(mangle, "air.thread_position_in_grid.z") uint get_global_id_z();
+pragma(LDC_intrinsic, "air.thread_position_in_grid.x") uint get_global_id_x();
+pragma(LDC_intrinsic, "air.thread_position_in_grid.y") uint get_global_id_y();
+pragma(LDC_intrinsic, "air.thread_position_in_grid.z") uint get_global_id_z();
 
 // thread_position_in_threadgroup → SharedIndex
-pragma(mangle, "air.thread_position_in_threadgroup.x") uint get_local_id_x();
-pragma(mangle, "air.thread_position_in_threadgroup.y") uint get_local_id_y();
-pragma(mangle, "air.thread_position_in_threadgroup.z") uint get_local_id_z();
+pragma(LDC_intrinsic, "air.thread_position_in_threadgroup.x") uint get_local_id_x();
+pragma(LDC_intrinsic, "air.thread_position_in_threadgroup.y") uint get_local_id_y();
+pragma(LDC_intrinsic, "air.thread_position_in_threadgroup.z") uint get_local_id_z();
 
 // threadgroup_position_in_grid → GroupIndex
-pragma(mangle, "air.threadgroup_position_in_grid.x") uint get_group_id_x();
-pragma(mangle, "air.threadgroup_position_in_grid.y") uint get_group_id_y();
-pragma(mangle, "air.threadgroup_position_in_grid.z") uint get_group_id_z();
+pragma(LDC_intrinsic, "air.threadgroup_position_in_grid.x") uint get_group_id_x();
+pragma(LDC_intrinsic, "air.threadgroup_position_in_grid.y") uint get_group_id_y();
+pragma(LDC_intrinsic, "air.threadgroup_position_in_grid.z") uint get_group_id_z();
 
 // threads_per_grid → GlobalDimension
-pragma(mangle, "air.threads_per_grid.x") uint get_global_size_x();
-pragma(mangle, "air.threads_per_grid.y") uint get_global_size_y();
-pragma(mangle, "air.threads_per_grid.z") uint get_global_size_z();
+pragma(LDC_intrinsic, "air.threads_per_grid.x") uint get_global_size_x();
+pragma(LDC_intrinsic, "air.threads_per_grid.y") uint get_global_size_y();
+pragma(LDC_intrinsic, "air.threads_per_grid.z") uint get_global_size_z();
 
 // threads_per_threadgroup → SharedDimension
-pragma(mangle, "air.threads_per_threadgroup.x") uint get_local_size_x();
-pragma(mangle, "air.threads_per_threadgroup.y") uint get_local_size_y();
-pragma(mangle, "air.threads_per_threadgroup.z") uint get_local_size_z();
+pragma(LDC_intrinsic, "air.threads_per_threadgroup.x") uint get_local_size_x();
+pragma(LDC_intrinsic, "air.threads_per_threadgroup.y") uint get_local_size_y();
+pragma(LDC_intrinsic, "air.threads_per_threadgroup.z") uint get_local_size_z();
 
 // threadgroups_per_grid → GroupDimension
-pragma(mangle, "air.threadgroups_per_grid.x") uint get_num_groups_x();
-pragma(mangle, "air.threadgroups_per_grid.y") uint get_num_groups_y();
-pragma(mangle, "air.threadgroups_per_grid.z") uint get_num_groups_z();
+pragma(LDC_intrinsic, "air.threadgroups_per_grid.x") uint get_num_groups_x();
+pragma(LDC_intrinsic, "air.threadgroups_per_grid.y") uint get_num_groups_y();
+pragma(LDC_intrinsic, "air.threadgroups_per_grid.z") uint get_num_groups_z();

--- a/source/dcompute/std/metal/sync.d
+++ b/source/dcompute/std/metal/sync.d
@@ -1,0 +1,28 @@
+@compute(CompileFor.deviceOnly) module dcompute.std.metal.sync;
+
+import ldc.dcompute;
+
+pure: nothrow: @nogc:
+
+alias mem_flags = uint;
+
+enum : mem_flags
+{
+    mem_none = 0,
+    mem_device = 1,
+    mem_threadgroup = 2,
+    mem_texture = 4,
+}
+
+enum uint threadgroup_scope = 1;
+
+/// Threadgroup-wide execution barrier with optional memory fence flags.
+/// Matches Julia Metal.jl `threadgroup_barrier(flag)` → `air.wg.barrier(flag, 1)`.
+/// See Apple’s `MemoryFlags` / MSL `threadgroup_barrier`.
+pragma(LDC_intrinsic, "air.wg.barrier")
+void wg_barrier(uint mem_flags, uint execution_scope);
+
+void threadgroup_barrier()(mem_flags flags = mem_none)
+{
+    wg_barrier(flags, threadgroup_scope);
+}

--- a/source/dcompute/std/metal/warp.d
+++ b/source/dcompute/std/metal/warp.d
@@ -1,0 +1,13 @@
+/// Metal simdgroup (warp) primitives for DCompute.
+@compute(CompileFor.deviceOnly) module dcompute.std.metal.warp;
+
+import ldc.dcompute;
+
+/// Metal `simd_shuffle_xor(val, mask)`.
+/// Exchanges `val` with the lane `lane_id ^ mask` within the SIMD group.
+pragma(LDC_intrinsic, "air.simd_shuffle_xor.s.i32")
+    int simdShuffleXor(int val, short mask);
+
+/// ditto — float version.
+pragma(LDC_intrinsic, "air.simd_shuffle_xor.s.f32")
+    float simdShuffleXor(float val, short mask);

--- a/source/dcompute/std/sync.d
+++ b/source/dcompute/std/sync.d
@@ -18,6 +18,9 @@ void barrier()
             cuda.barrier0();
         }
     }
+    // Metal: use `dcompute.std.metal.sync.wg_barrier(0, 1)` — importing this
+    // module’s `barrier()` from a `@compute` kernel currently triggers
+    // dcompute semantic analysis on OCL/CUDA helpers (see LDC issue / follow-up).
 }
 
 void local_fence()

--- a/source/dcompute/std/sync.d
+++ b/source/dcompute/std/sync.d
@@ -3,24 +3,24 @@
 import ldc.dcompute;
 import ldc.intrinsics;
 
-import ocl  = dcompute.std.opencl.sync;
-import cuda = dcompute.std.cuda.sync;
+import ocl   = dcompute.std.opencl.sync;
+import cuda  = dcompute.std.cuda.sync;
+import metal = dcompute.std.metal.sync;
 
 //suspends work-item execution until all work-items in the work-group have called the barrier
-void barrier()
+void barrier()()
 {
     if(__dcompute_reflect(ReflectTarget.OpenCL))
         ocl.barrier(0);
-    if(__dcompute_reflect(ReflectTarget.CUDA)) {
+    else if(__dcompute_reflect(ReflectTarget.CUDA)) {
         static if (LLVM_atleast!21) { // >= LDC 1.42.0(LLVM 21)
             cuda.barrier_n(0);
         } else {
             cuda.barrier0();
         }
     }
-    // Metal: use `dcompute.std.metal.sync.wg_barrier(0, 1)` — importing this
-    // module’s `barrier()` from a `@compute` kernel currently triggers
-    // dcompute semantic analysis on OCL/CUDA helpers (see LDC issue / follow-up).
+    else if(__dcompute_reflect(ReflectTarget.Metal))
+        metal.threadgroup_barrier(metal.mem_none);
 }
 
 void local_fence()

--- a/source/dcompute/tests/add.metal
+++ b/source/dcompute/tests/add.metal
@@ -1,0 +1,11 @@
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void vec_add(
+    device const float* a [[buffer(0)]],
+    device const float* b [[buffer(1)]],
+    device float* out [[buffer(2)]],
+    uint id [[thread_position_in_grid]])
+{
+    out[id] = a[id] + b[id];
+}

--- a/source/dcompute/tests/metal_test.d
+++ b/source/dcompute/tests/metal_test.d
@@ -1,0 +1,70 @@
+module dcompute.tests.metal_test;
+
+import std.math : fabs;
+import std.stdio : writeln;
+import dcompute.driver.metal;
+
+private int fail(const(char)[] msg) {
+    writeln(msg);
+    return 1;
+}
+
+int main() {
+    enum n = 1024;
+    float[n] hostA;
+    float[n] hostB;
+    foreach (i; 0 .. n) {
+        hostA[i] = cast(float) i;
+        hostB[i] = cast(float) (i * 2);
+    }
+
+    Platform.initialise();
+    auto devices = Platform.getDevices();
+    auto dev = devices[0];
+    auto device = dev.raw;
+    if (device is null) return fail("FAIL: MTLCreateSystemDefaultDevice returned null.");
+    scope(exit) dev.release();
+
+    auto queue = Queue(dev);
+    if (queue.raw is null) return fail("FAIL: newCommandQueue returned null.");
+    scope(exit) queue.release();
+
+    auto program = Program.fromDefaultDevice();
+    auto library = program.loadLibrary("add.metallib");
+    if (library.raw is null) return fail("FAIL: cannot load add.metallib");
+    scope(exit) program.release();
+
+    auto kernel = program.getKernel("vec_add");
+    if (kernel.pipeline.raw is null) return fail("FAIL: newComputePipelineStateWithFunction failed.");
+    scope(exit) kernel.release();
+
+    Buffer!float aBuffer = Buffer!float(hostA[]);
+    Buffer!float bBuffer = Buffer!float(hostB[]);
+    Buffer!float outBuffer = Buffer!float(n);
+    if (aBuffer.raw is null || bBuffer.raw is null || outBuffer.raw is null) {
+        return fail("FAIL: buffer allocation failed.");
+    }
+    scope(exit) aBuffer.release();
+    scope(exit) bBuffer.release();
+    scope(exit) outBuffer.release();
+
+    queue.enqueue(kernel, mtlSize(n, 1, 1), mtlSize(64, 1, 1))
+        (aBuffer, bBuffer, outBuffer);
+
+    auto outPtr = cast(float*) outBuffer.contents();
+    if (outPtr is null) return fail("FAIL: output buffer has null contents.");
+
+    bool ok = true;
+    foreach (i; 0 .. n) {
+        auto expected = hostA[i] + hostB[i];
+        if (fabs(outPtr[i] - expected) > 1e-6f) {
+            ok = false;
+            writeln("Mismatch at ", i, ": got=", outPtr[i], " expected=", expected);
+            break;
+        }
+    }
+
+    writeln("Sample output: out[0]=", outPtr[0], ", out[1]=", outPtr[1], ", out[2]=", outPtr[2]);
+    writeln(ok ? "PASS: Metal vector add succeeded." : "FAIL: Metal vector add validation failed.");
+    return ok ? 0 : 2;
+}


### PR DESCRIPTION
Start a minimal Metal bindings and mimic cuda or ocl's style. I am not sure whether it's a right direction.
One major blocker was an Objective-C interop RTTI/linker problem in D:
- Storing extern(Objective-C) interface types directly in wrapper structs sometimes(not always, but at most time, strange) caused LDC to emit RTTI/classinfo references such as __Interface / __Class.
- Those symbols are not provided by the Objective-C runtime, which led to undefined-symbol linker errors.
- The fix was to store Objective-C handles as raw void* internally and cast at the wrapper boundary, avoiding unwanted RTTI emission.