### PR TITLE
Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ There are four main parts:
 
 ## Examples
 
+> **Note:** The `@kernel()` syntax requires LDC 1.42 or later. If you are using an older version of LDC, please use `@kernel` (without parentheses).
+
 Kernel:
 ```
-@kernel void saxpy(GlobalPointer!(float) res,
+@kernel() void saxpy(GlobalPointer!(float) res,
                    float alpha,
                    GlobalPointer!(float) x,
                    GlobalPointer!(float) y, 

--- a/docs/03-kernels.md
+++ b/docs/03-kernels.md
@@ -1,15 +1,17 @@
 Kernels
 =======
 
-At the heart of DCompute is are the special attributes `@compute` and `@kernel` from the module `ldc.dcompute`
+At the heart of DCompute is are the special attributes `@compute` and `@kernel()` from the module `ldc.dcompute`
+
+> **Note:** The `@kernel()` syntax requires LDC 1.42 or later. If you are using an older version of LDC, please use `@kernel` (without parentheses).
 
 `@compute` tell the d compiler that this module should be built to target the device. 
 `@compute` takes a single parameter that Indicate wether to target only the device 
 (`@compute(CompileFor.deviceOnly)`) or to target host as well (`@compute(CompileFor.hostAndDevice)`).
 
-`@kernel` specifies that the attached function should be an entry point for the device,
+`@kernel()` specifies that the attached function should be an entry point for the device,
 i.e. you can tell the driver to execute this function on the device, 
-whereas you can't for functions that aren't marked `@kernel`.
+whereas you can't for functions that aren't marked `@kernel()`.
 
 Address Spaces 
 --------------
@@ -49,12 +51,12 @@ The table below shows the equivalent terms in DCompute, OpenCL and CUDA.
 Hello World
 -----------
 
-About the simplest kernel you can have is shown below (note that @kernel functions MUST return `void` or you'll get errors)
+About the simplest kernel you can have is shown below (note that @kernel() functions MUST return `void` or you'll get errors)
 
 ```d
 @compute(CompileFor.deviceOnly) module mykernels;
 import ldc.dcompute;
-@kernel void mykernel(GlobalPointer!float a,GlobalPointer!float b, float c)
+@kernel() void mykernel(GlobalPointer!float a,GlobalPointer!float b, float c)
 {
 *a = *b + c;
 }
@@ -92,6 +94,6 @@ D:
 @compute(CompileFor.deviceOnly)
 module bar;
 
-extern(C) @kernel void foo();
+extern(C) @kernel() void foo();
 ```
 

--- a/docs/04-std/01-index.md
+++ b/docs/04-std/01-index.md
@@ -42,7 +42,7 @@ import ldc.attributes;
 import ldc.dcompute;
 import dcompute.std.index;
 alias gf = GlobalPointer!float;
-@kernel void mykernel(gf a, gf b, float c)
+@kernel() void mykernel(gf a, gf b, float c)
 {
     auto i = GlobalIndex.x;
     a[i] = b[i] + c;

--- a/source/dcompute/tests/test.d
+++ b/source/dcompute/tests/test.d
@@ -5,7 +5,7 @@ import ldc.dcompute;
 import dcompute.std.index;
 import std.traits;
 
-@kernel
+@kernel()
 void map(alias F)(GlobalPointer!(ReturnType!(F)) r, Parameters!F args)
 {
     r[GlobalIndex.x] = F(args);


### PR DESCRIPTION
This PR modernizes the documentation, examples, and test files to use the updated @kernel()  syntax introduced for LDC 1.42. It also provides backward compatibility guidance for users on older compiler versions.

Changes
Documentation:
Updated README.md and standard standard library docs (docs/03-kernels.md, docs/04-std/01-index.md) to use @kernel() in examples.
Added compatibility notes explaining that @kernel (without parentheses) should be used for LDC versions prior to 1.42.
Tests:
Updated the map kernel in source/dcompute/tests/test.d to use @kernel().