### PR TITLE
Make std.sync.barrier a zero-arg template for device codegen

### DIFF
--- a/source/dcompute/std/sync.d
+++ b/source/dcompute/std/sync.d
@@ -7,7 +7,7 @@ import ocl  = dcompute.std.opencl.sync;
 import cuda = dcompute.std.cuda.sync;
 
 //suspends work-item execution until all work-items in the work-group have called the barrier
-void barrier()
+void barrier()()
 {
     if(__dcompute_reflect(ReflectTarget.OpenCL))
         ocl.barrier(0);


### PR DESCRIPTION
## Summary
- Change `barrier()` to `barrier()()` so it follows the same device codegen model as `GlobalIndex` helpers
- The barrier body is instantiated into importing kernel modules rather than requiring separate compilation of the dcompute library object

Fixes #95

## Test plan
- [ ] `dub test` (CUDA/OpenCL targets as available)
- [ ] Confirm kernel modules still compile with `barrier()` calls unchanged at the call site
