### PR TITLE
Fix OpenCL Device.addressBits cl_device_info constant

### DIFF
--- a/source/dcompute/driver/ocl/device.d
+++ b/source/dcompute/driver/ocl/device.d
@@ -81,7 +81,7 @@ struct Device
         @(0x100A) uint preferredVectorWidthFloat;
         @(0x100B) uint preferredVectorWidthDouble;
         @(0x100C) uint maxClockFrequency;
-        @(0x1000) uint addressBits;
+        @(0x100D) uint addressBits;
         @(0x100E) uint maxReadImageArgs;
         @(0x100F) uint maxWriteImageArgs;
         @(0x1010) ulong maxMemoryAllocSize;


### PR DESCRIPTION
## Summary

`Device.Info.addressBits` was annotated with `0x1000` (`CL_DEVICE_TYPE`) instead of `0x100D` (`CL_DEVICE_ADDRESS_BITS`), so `device.addressBits` did not query the device address width.

This changes the UDA to `0x100D` to match [OpenCL `cl.h`](https://github.com/KhronosGroup/OpenCL-Headers/blob/main/CL/cl.h).

Fixes #102

## Test plan

- [ ] Confirm `source/dcompute/driver/ocl/device.d` has `@(0x100D) uint addressBits`
- [ ] On a machine with OpenCL, compare `device.addressBits` with `clinfo` / `clGetDeviceInfo(..., CL_DEVICE_ADDRESS_BITS, ...)`