### PR TITLE
Fix OpenCL LocalMemoryType and ExecutionCapabilities values

### DIFF
--- a/source/dcompute/driver/ocl/device.d
+++ b/source/dcompute/driver/ocl/device.d
@@ -55,14 +55,14 @@ struct Device
     
     enum LocalMemoryType : cl_uint
     {
-        local,
-        global,
+        local  = 0x1, // CL_LOCAL
+        global = 0x2, // CL_GLOBAL
     }
     
     enum ExecutionCapabilities : cl_bitfield
     {
-        kernel,
-        nativeKernel,
+        kernel       = 1 << 0, // CL_EXEC_KERNEL
+        nativeKernel = 1 << 1, // CL_EXEC_NATIVE_KERNEL
     }
     
     static struct Info

--- a/source/dcompute/driver/ocl/device.d
+++ b/source/dcompute/driver/ocl/device.d
@@ -55,14 +55,14 @@ struct Device
     
     enum LocalMemoryType : cl_uint
     {
-        local  = 0x1, // CL_LOCAL
-        global = 0x2, // CL_GLOBAL
+        local  = 0x1,
+        global = 0x2,
     }
     
     enum ExecutionCapabilities : cl_bitfield
     {
-        kernel       = 1 << 0, // CL_EXEC_KERNEL
-        nativeKernel = 1 << 1, // CL_EXEC_NATIVE_KERNEL
+        kernel       = 1 << 0,
+        nativeKernel = 1 << 1,
     }
     
     static struct Info


### PR DESCRIPTION
## Summary

`LocalMemoryType` and `ExecutionCapabilities` in `device.d` used default D enum numbering (`0`, `1`) instead of the OpenCL values from [`cl.h`](https://github.com/KhronosGroup/OpenCL-Headers/blob/main/CL/cl.h):

- `CL_LOCAL` / `CL_GLOBAL` → `1` / `2`
- `CL_EXEC_KERNEL` / `CL_EXEC_NATIVE_KERNEL` → `1 << 0` / `1 << 1`

Raw `clGetDeviceInfo` reads were already fine after #84; named comparisons and bit tests were not.

Fixes #103

## Test plan

- [ ] Confirm the two enums have the explicit values above
- [ ] On a machine with OpenCL, check `d.localMemoryType == Device.LocalMemoryType.local` on a `CL_LOCAL` device
- [ ] Check `(d.executionCapabilities & Device.ExecutionCapabilities.kernel) != 0` when the device reports `CL_EXEC_KERNEL`