### PR TITLE
Make CUDA runtime init soft-fail when no device is present

### DIFF
--- a/source/dcompute/driver/cuda/platform.d
+++ b/source/dcompute/driver/cuda/platform.d
@@ -17,6 +17,29 @@ struct Platform
         status = cast(Status)cuInit(flags);
         checkErrors();
     }
+
+    /**
+     * Soft-failing variant of initialise() for use from module constructors,
+     * where an uncaught exception aborts the program before main() starts.
+     *
+     * Probes the CUDA driver without throwing and without touching the
+     * thread-local `status`: loads the shared library, calls cuInit and
+     * checks that at least one device is present.
+     *
+     * Returns: true if CUDA is fully usable on this machine.
+     */
+    static bool tryInitialise(uint flags = 0)
+    {
+        auto support = loadCUDA();
+        if (support == CUDASupport.noLibrary || support == CUDASupport.badLibrary)
+            return false;
+        if (cast(Status)cuInit(flags) != Status.Success)
+            return false;
+        int deviceCount;
+        if (cast(Status)cuDeviceGetCount(&deviceCount) != Status.Success)
+            return false;
+        return deviceCount > 0;
+    }
     
     static Device[] getDevices(A)(A a)
     {

--- a/source/dcompute/driver/cuda/runtime.d
+++ b/source/dcompute/driver/cuda/runtime.d
@@ -16,6 +16,12 @@
  * ensureInit() is kept as a defensive fallback.  It is a no-op once the
  * module constructors have run, so calling it is always safe and costs only
  * a single bool check on the fast path.
+ *
+ * On machines without a CUDA driver or device the module constructors fail
+ * softly: they mark CUDA as unavailable and return quietly, so merely linking
+ * against this module never aborts a program before main().  The first actual
+ * attempt to use the runtime (via ensureInit()) then throws a clear,
+ * catchable DComputeDriverException.
  */
 module dcompute.driver.cuda.runtime;
 
@@ -26,7 +32,8 @@ import std.experimental.allocator.mallocator : Mallocator;
 // __gshared: lives in a single memory location, accessible from all threads.
 private __gshared Device  _defaultDevice;
 private __gshared Context _defaultContext;
-private __gshared bool    _platformReady = false; // safety-net flag
+private __gshared bool    _platformReady  = false; // safety-net flag
+private __gshared bool    _cudaAvailable  = true;  // cleared if init fails
 
 // Thread-local state
 // plain `static`: D gives each thread its own copy automatically.
@@ -38,9 +45,7 @@ private static bool  _threadReady = false; // safety-net flag
 // in module-dependency order.  No locking needed here.
 shared static this()
 {
-    version(LDC_DCompute_CUDA) {
-        _initPlatform();
-    }
+    _initPlatform();
 }
 
 // Per-thread init: thread-local static constructor
@@ -48,9 +53,7 @@ shared static this()
 // that thread begins.  For the main thread it runs after shared static this().
 static this()
 {
-    version(LDC_DCompute_CUDA) {
-      _initThread();
-  }
+    _initThread();
 }
 
 // Public API
@@ -69,6 +72,9 @@ static this()
 void ensureInit()
 {
     if (!_platformReady) _initPlatform(); // global guard (synchronized inside)
+    if (!_cudaAvailable)
+        throw new DComputeDriverException(
+            "No CUDA driver or device available on this system.");
     if (!_threadReady)   _initThread();   // per-thread guard (no lock, TLS)
 }
 
@@ -100,32 +106,57 @@ private void _initPlatform()
     {
         if (_platformReady) return;
 
-        Platform.initialise();
-        // Device 0 is the default.  Users needing a specific device can call
-        // Platform.getDevices() and manage their own Context + Queue.
-        
-        // TODO : Make multi-device usage better and easy.
-        _defaultDevice = Platform.getDevices(Mallocator.instance)[0];
+        // This runs on the module-constructor path, where an uncaught
+        // exception aborts the program before main() starts.  On machines
+        // without a CUDA driver or device, mark CUDA unavailable and return
+        // quietly — ensureInit() reports the problem with a catchable
+        // exception if the runtime is actually used.
+        if (!Platform.tryInitialise())
+        {
+            _cudaAvailable = false;
+            return;
+        }
 
-        // cuCtxCreate creates the context AND pushes it onto the calling
-        // thread's CUDA context stack.
-        _defaultContext = Context(_defaultDevice);
+        try
+        {
+            // Device 0 is the default.  Users needing a specific device can call
+            // Platform.getDevices() and manage their own Context + Queue.
 
-        // Compile-time PTX embedding
-        // LDC compiles @compute modules to PTX first, then compiles host code,
-        // so import() resolves in a single build pass with no file I/O at
-        // runtime.
-        // The version ladder is pure data — one line per SM level.  Adding a
-        // new target only requires one new `else version` line here plus the
-        // matching "DComputeCUDA_XXX" entry in dub.json.
+            // TODO : Make multi-device usage better and easy.
+            _defaultDevice = Platform.getDevices(Mallocator.instance)[0];
 
-        _platformReady = true;
+            // cuCtxCreate creates the context AND pushes it onto the calling
+            // thread's CUDA context stack.
+            _defaultContext = Context(_defaultDevice);
+
+            // Compile-time PTX embedding
+            // LDC compiles @compute modules to PTX first, then compiles host code,
+            // so import() resolves in a single build pass with no file I/O at
+            // runtime.
+            // The version ladder is pure data — one line per SM level.  Adding a
+            // new target only requires one new `else version` line here plus the
+            // matching "DComputeCUDA_XXX" entry in dub.json.
+
+            _platformReady = true;
+        }
+        catch (Exception)
+        {
+            // Backstop: never let an exception escape into the module-ctor
+            // path.  Reset the thread-local driver status so a later
+            // checkErrors() does not spuriously re-throw it.
+            status = Status.Success;
+            _cudaAvailable = false;
+        }
     }
 }
 
 private void _initThread()
 {
     if (_threadReady) return;
+
+    // Nothing to bind this thread to when platform init failed (no CUDA
+    // driver/device) or has not run yet.
+    if (!_platformReady) return;
 
     // The thread that ran _initPlatform() already has _defaultContext on its
     // CUDA context stack (cuCtxCreate pushes automatically).

--- a/source/dcompute/tests/main.d
+++ b/source/dcompute/tests/main.d
@@ -34,6 +34,19 @@ enum CL_PLATFORM_INDEX = 2;
 
 int main(string[] args)
 {
+    version (DComputeTestCUDA)
+    {
+        // Soft-fail init test (see dcompute.tests.runtime_init).  Opt-in via
+        // env var because it must run with the CUDA devices masked, e.g.:
+        //     DCOMPUTE_TEST_NO_CUDA=1 CUDA_VISIBLE_DEVICES="" ./dcompute
+        import std.process : environment;
+        if (environment.get("DCOMPUTE_TEST_NO_CUDA") !is null)
+        {
+            import dcompute.tests.runtime_init : runNoCudaInitTest;
+            return runNoCudaInitTest();
+        }
+    }
+
     enum size_t N = 128;
     float alpha = 5.0;
     float[N] res, x,y;

--- a/source/dcompute/tests/runtime_init.d
+++ b/source/dcompute/tests/runtime_init.d
@@ -1,0 +1,50 @@
+/**
+ * dcompute.tests.runtime_init
+ *
+ * Verifies the soft-fail behaviour of the CUDA runtime module constructors
+ * on machines without a usable CUDA driver/device.
+ *
+ * Opt-in via environment variable, with the devices masked so that
+ * initialisation cannot succeed:
+ *
+ *     DCOMPUTE_TEST_NO_CUDA=1 CUDA_VISIBLE_DEVICES="" ./dcompute
+ *
+ * Merely reaching main() already proves half the fix: the module
+ * constructors must not abort the program when CUDA is unavailable.  The
+ * rest asserts that the first actual use of the runtime (ensureInit) reports
+ * the condition with a clear, catchable exception instead.
+ */
+module dcompute.tests.runtime_init;
+
+version (DComputeTesting) version = DComputeRuntimeInitTest;
+version (DComputeTestCUDA) version = DComputeRuntimeInitTest;
+
+version (DComputeRuntimeInitTest):
+
+import std.stdio;
+
+import dcompute.driver.cuda.runtime : ensureInit;
+import dcompute.driver.error : DComputeDriverException;
+
+/// Returns 0 on pass, 1 on failure (used as the process exit code).
+int runNoCudaInitTest()
+{
+    // Reaching this function at all means the process survived the module
+    // constructors with no usable CUDA — the primary claim under test.
+    writeln("Module constructors survived without a usable CUDA device.");
+
+    try
+    {
+        ensureInit();
+    }
+    catch (DComputeDriverException e)
+    {
+        writeln("ensureInit() threw as expected: ", e.msg);
+        writeln("runtime_init no-CUDA test PASSED.");
+        return 0;
+    }
+
+    stderr.writeln("FAIL: ensureInit() succeeded — CUDA appears to be usable. ",
+                   "Run this test with the devices masked, e.g. CUDA_VISIBLE_DEVICES=\"\".");
+    return 1;
+}


### PR DESCRIPTION

Follows up on #100 - ensure the runtime module does not cause issues trying to load itself when no CUDA is present.

The guard from #100 doesn't achieve this: it wraps `runtime.d`'s module constructors in `version(LDC_DCompute_CUDA)`, but no compiler defines that identifier — LDC predefines only `LDC_DCompute` The constructors are therefore compiled out in every build, and on machines that *do* have a GPU the default context is never created: 
## Changes
- New `Platform.tryInitialise()`: a soft-failing probe that never throws and never mutates the thread-local error status - checks `loadCUDA()` (noLibrary/badLibrary), the `cuInit` result, and `cuDeviceGetCount > 0`.
- `_initPlatform()` marks CUDA unavailable and returns quietly when the probe fails; device/context creation is wrapped in a defensive try/catch so nothing can escape `shared static this()` and abort the process before `main()`.
- Per-thread `static this()` no-ops when the platform isn't ready.
- `ensureInit()` now throws a catchable `DComputeDriverException("No CUDA driver or device available on this system.")` when CUDA is absent, so `launch!`'s lazy-init path reports cleanly instead of failing later with a confusing `invalidContext`.


## Verification (RTX 2050; device masking via CUDA_VISIBLE_DEVICES)
| Scenario | Before | After |
|---|---|---|
| CUDA build, GPU present | suite fails (`invalidContext`, exit 1) | unmodified suite passes (exit 0) |
| CUDA build, device masked (`""` / `-1`) | constructors dead, `invalidContext` on first Buffer | survives constructors; clear catchable error on first CUDA use |
| OpenCL build (also compiles `cuda/runtime.d`), CUDA masked | — | constructors run and soft-fail quietly; program proceeds into OpenCL host code |

An opt-in automated test in `tests/runtime_init.d` (env-guarded) covers the no-device path: `DCOMPUTE_TEST_NO_CUDA=1 CUDA_VISIBLE_DEVICES="" ./dcompute` verifies the constructors survive and `ensureInit()` throws as expected.
